### PR TITLE
[RFC] Remove httppost from the template

### DIFF
--- a/templates/kapacitor.conf.j2
+++ b/templates/kapacitor.conf.j2
@@ -1,5 +1,4 @@
 # {{ ansible_managed }}
-httppost = {{ kapacitor_httppost|to_json }}
 hostname = {{ kapacitor_hostname|to_json }}
 data_dir = {{ kapacitor_data_dir|to_json }}
 skip-config-overrides = {{ kapacitor_skip_config_overrides|to_json }}


### PR DESCRIPTION
This is a quick fix to allow configuration of the HTTP Post hook with ansible.

I still have not gotten it to work with this role, but I think this is one of the fixes needed to make it work.