### PR TITLE
Enable use of "load" section

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -173,3 +173,5 @@ kapacitor_deadman_id: "{%raw%}node 'NODE_NAME' in task '{{ .TaskName }}'{%endraw
 kapacitor_deadman_interval: "10s"
 kapacitor_deadman_message: '{%raw%}{{ .ID }} is {{ if eq .Level \"OK\" }}alive{{ else }}dead{{ end }}: {{ index .Fields \"collected\" | printf \"%0.3f\" }} points/INTERVAL.{%endraw%}'
 kapacitor_deadman_threshold: 0.0
+kapacitor_load_enable: false
+kapacitor_load_dir: ""

--- a/templates/kapacitor.conf.j2
+++ b/templates/kapacitor.conf.j2
@@ -189,3 +189,6 @@ default-retention-policy = "{{ kapacitor_default_retention_policy }}"
   message = "{{ kapacitor_deadman_message }}"
   threshold = {{ kapacitor_deadman_threshold | to_json }}
 
+[load]
+  enabled = {{ kapacitor_load_enabled | to_json }}
+  dir = "{{ kapacitor_load_dir }}"


### PR DESCRIPTION
Currently there is no way of configuring the module to use "load" section available in Kapacitor. This commit adds capability to enable it and configure a directory to consume.