### PR TITLE
make kapacitor_http_auth_enabled boolean

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ kapacitor_rpm_pkg_url: 'https://dl.influxdata.com/kapacitor/releases/kapacitor-{
 kapacitor_config_file: '/etc/kapacitor/kapacitor.conf'
 kapacitor_apt_repo_url: "deb https://repos.influxdata.com/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 kapacitor_http_shared_secret: ""
-kapacitor_http_auth_enabled: 'true'
+kapacitor_http_auth_enabled: true
 kapacitor_tick_work_dir: "/usr/local/etc/kapacitor/tick"
 kapacitor_tick_script_dest_dir: "{{ kapacitor_tick_work_dir }}/script"
 kapacitor_tick_template_dest_dir: "{{ kapacitor_tick_work_dir }}/template"


### PR DESCRIPTION
Otherwise kapacitor will not start with the error

`run: parse config: toml: cannot load TOML value of type string into a Go boolean`